### PR TITLE
sourceにアプリケーション音声キャプチャ(OBS 28～)を追加

### DIFF
--- a/app/i18n/en-US/source-props.json
+++ b/app/i18n/en-US/source-props.json
@@ -393,5 +393,8 @@
   "near": {
     "name": "KOTOYOMI Near",
     "description": "Add a character to your scene that reads comments to the \"N Voice\" voice."
+  },
+  "wasapi_process_output_capture": {
+    "name": "Application Audio Capture (BETA)"
   }
 }

--- a/app/i18n/ja-JP/source-props.json
+++ b/app/i18n/ja-JP/source-props.json
@@ -393,5 +393,8 @@
   "near": {
     "name": "琴詠ニア",
     "description": "シーンにN Voiceの音声に合わせてコメントを読み上げるキャラクターを追加します"
+  },
+  "wasapi_process_output_capture": {
+    "name": "アプリケーション音声キャプチャ(β版)"
   }
 }

--- a/app/services/sources/sources-api.ts
+++ b/app/services/sources/sources-api.ts
@@ -109,7 +109,9 @@ export type TSourceType =
   | 'openvr_capture'
   | 'liv_capture'
   | 'ovrstream_dc_source'
-  | 'vlc_source';
+  | 'vlc_source'
+  | 'wasapi_process_output_capture'
+  ;
 
 // Register new properties manager here
 export type TPropertiesManager = 'default' | 'nvoice-character';

--- a/app/services/sources/sources.ts
+++ b/app/services/sources/sources.ts
@@ -342,6 +342,7 @@ export class SourcesService extends StatefulService<ISourcesState> implements IS
       'liv_capture',
       'ovrstream_dc_source',
       'vlc_source',
+      'wasapi_process_output_capture',
     ];
 
     const availableWhitelistedType = whitelistedTypes.filter(type =>


### PR DESCRIPTION
# このpull requestが解決する内容
OBS Studio 28で追加された wasapi_process_output_capture (アプリケーション音声キャプチャ)を有効にします

![image](https://user-images.githubusercontent.com/864587/237062015-e1ff2306-f741-489b-bd34-e0e7b34c39b9.png)
![image](https://user-images.githubusercontent.com/864587/237062103-eb816084-4d2c-4a00-b65e-fb890223175e.png)

文言はOBS Studio 28の表示に合わせてます
