### PR TITLE
修正: Webページ(browser)ソースのreroute_audioの文言をN Airにする

### DIFF
--- a/app/i18n/en-US/source-props.json
+++ b/app/i18n/en-US/source-props.json
@@ -40,6 +40,9 @@
     "local_file": {
       "name": "Local file"
     },
+    "reroute_audio": {
+      "name": "Control audio via N Air"
+    },
     "refreshnocache": {
       "name": "Refresh cache of current page"
     },

--- a/app/i18n/ja-JP/source-props.json
+++ b/app/i18n/ja-JP/source-props.json
@@ -40,6 +40,9 @@
     "local_file": {
       "name": "ローカルファイル"
     },
+    "reroute_audio": {
+      "name": "N Airを介して音声を制御する"
+    },
     "refreshnocache": {
       "name": "キャッシュを消去して再読み込み"
     },


### PR DESCRIPTION
# このpull requestが解決する内容
![image](https://github.com/asaday/n-air-app/assets/864587/7e4d82e0-a754-4dd3-9864-4935f2c6ee58)

# 動作確認手順
Webページソースのプロパティを開く
